### PR TITLE
Use assumed high-available keyserver hostname

### DIFF
--- a/roles/docker-engine/tasks/main.yml
+++ b/roles/docker-engine/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add Docker APT key
-  apt_key: keyserver="hkp://p80.pool.sks-keyservers.net:80" id=58118E89F3A912897C070ADBF76221572C52609D state=present
+  apt_key: keyserver=ha.pool.sks-keyservers.net id=58118E89F3A912897C070ADBF76221572C52609D state=present
 
 - name: Add Docker APT repo
   apt_repository: repo="deb https://apt.dockerproject.org/repo ubuntu-trusty main" state=present


### PR DESCRIPTION
Fixes the following error:

```
failed: [10.141.141.12] => {"cmd": "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 58118E89F3A912897C070ADBF76221572C52609D", "failed": true, "rc": 2}
stderr: gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0

stdout: Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.4dczvwmUsC --no-auto-check-trustdb --trust-model always --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 58118E89F3A912897C070ADBF76221572C52609D
gpgkeys: key 58118E89F3A912897C070ADBF76221572C52609D can't be retrieved

msg: gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```
