### PR TITLE
dcos-cli: configure dcos_url

### DIFF
--- a/roles/dcos-cli/templates/dcos.toml.j2
+++ b/roles/dcos-cli/templates/dcos.toml.j2
@@ -1,5 +1,6 @@
 # {{ansible_managed}}
 [core]
+dcos_url = "http://master.mesos:5050/"
 mesos_master_url = "http://master.mesos:5050"
 reporting = false # No usage reporting
 email = "no-auth@example.com" # Disables auth check


### PR DESCRIPTION
The dcos_url is used by the `dcos node` subcommand. Note that the `node ssh` command does not work since it requires that the Mesos DNS API is exposed on one of the externally accessible nodes in the cluster under `/mesos_dns`.

```
$ dcos node ssh --master
Error while fetching [http://master.mesos:5050/mesos_dns/v1/hosts/leader.mesos.]: HTTP 404: Not Found
```
