### PR TITLE
Upgrade Marathon to 0.13.0 and Mesos to 0.25.0

### DIFF
--- a/roles/mesos-master/defaults/main.yml
+++ b/roles/mesos-master/defaults/main.yml
@@ -5,7 +5,7 @@
 # version suffixes added by Mesosphere.
 #
 # To install the latest use `latest`, to install latest 0.11 use `0.11`.
-marathon_version: "0.11.1"
+marathon_version: "0.13.0"
 chronos_version: "2.4.0"
 
 cluster_name: "Mediative Performance Network"

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -5,7 +5,7 @@
 # version suffixes added by Mesosphere.
 #
 # To install the latest use `latest`, to install latest 0.11 use `0.11`.
-mesos_version: "0.24.1"
+mesos_version: "0.25.0"
 
 ## Additional /etc/hosts mappings
 #


### PR DESCRIPTION
To match the versions used in DCOS 1.4:
- http://docs.mesosphere.com/overview/release-notes/dcos1-4/
